### PR TITLE
Automatically infer `stable` and `dev` versions based on semver spec

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,8 +35,8 @@ and then set up your environment in typedoc.json
 
 | Key               | Value Information                                                                                                         | Type     | Required | Default                                                                 |
 | :---------------- | ------------------------------------------------------------------------------------------------------------------------- | -------- | :------: | ----------------------------------------------------------------------- |
-| **_stable_**      | The minor version that you would like to be marked as `stable`                                                            | `string` |  **no**  | The latest minor version of the version being built                     |
-| **_dev_**         | The version that you would like to be marked as `dev`                                                                     | `string` |  **no**  | The latest patch version of the version being built                     |
+| **_stable_**      | The version that you would like to be marked as `stable`                                                                  | `string` |  **no**  | Automatically inferred based on current version and build history.      |
+| **_dev_**         | The version that you would like to be marked as `dev`                                                                     | `string` |  **no**  | Automatically inferred based on current version and build history.      |
 | **_domLocation_** | A custom DOM location to render the HTML `select` dropdown corresponding to typedoc rendererHooks, eg. "navigation.begin" | `string` |  **no**  | Injects to left of header using vanilla js - not a typedoc render hook. |
 
 <br /><br />

--- a/src/assets/versionsMenu.js
+++ b/src/assets/versionsMenu.js
@@ -10,10 +10,12 @@ DOC_VERSIONS.forEach((version) => {
 });
 
 const locationSplit = location.pathname.split('/');
-const thisVersion = locationSplit.find(
-	(path) => DOC_VERSIONS.indexOf(path) > -1
+const thisVersion = locationSplit.find((path) =>
+	['stable', 'dev', ...DOC_VERSIONS].includes(path)
 );
-select.value = thisVersion;
+select.value = DOC_VERSIONS.includes(thisVersion)
+	? thisVersion
+	: DOC_VERSIONS[0];
 select.onchange = () => {
 	const newPaths = window.location.pathname.replace(
 		`/${thisVersion}/`,

--- a/src/etc/utils.ts
+++ b/src/etc/utils.ts
@@ -6,7 +6,7 @@
 
 import path from 'path';
 import fs from 'fs-extra';
-import semver, { SemVer } from 'semver';
+import semver from 'semver';
 import { version, semanticAlias, versionsOptions } from '../types';
 import { Application, Logger, TypeDocReader } from 'typedoc';
 const packagePath = path.join(process.cwd(), 'package.json');
@@ -19,18 +19,20 @@ const pack = fs.readJSONSync(packagePath);
  * @todo grab potential labels from the version and provide them as further pegs in the menu.
  */
 export function getSemanticVersion(version: string = pack.version): version {
-	!version &&
-		(() => {
-			throw new Error('Package version was not found');
-		})();
+	if (!version) {
+		throw new Error('Package version was not found');
+	}
 
 	const semVer = semver.coerce(version, { loose: true });
-
 	if (!semVer) {
 		throw new Error(`version is not semantically formatted: ${version}`);
 	}
 
-	return `v${semVer.version}`;
+	// ensure prerelease info remains appended
+	const prerelease = semver.prerelease(version, true);
+	return prerelease
+		? `v${semVer.version}-${semver.prerelease(version, true).join('.')}`
+		: `v${semVer.version}`;
 }
 
 /**
@@ -39,7 +41,6 @@ export function getSemanticVersion(version: string = pack.version): version {
  */
 export function getMinorVersion(version?: string): version {
 	version = getSemanticVersion(version);
-
 	const { major, minor } = semver.coerce(version, { loose: true });
 	return `v${major}.${minor}`;
 }
@@ -57,96 +58,76 @@ export function getPackageDirectories(docRoot: string): string[] {
 }
 
 /**
- * Creates groups of semantic versions with the latest patch version identified
- * @param directories an array of semantically named directories to be processed
- * @returns
+ * Gets a list of semantic versions from a list of directories, sorted in descending order.
+ * @param directories An array of semantically named directories to be processed
+ * @returns An array of {@link version versions}, sorted in descending order.
  */
-export function getSemVers(directories: string[]): SemVer[] {
+export function getVersions(directories: string[]): version[] {
 	return directories
-		.map((dir) => semver.coerce(dir, { loose: true })) // parse directory names to SemVer instances (convert to (SemVer | null)[])
-		.filter((v) => v instanceof SemVer) // discard nulls (convert to SemVer[])
-		.sort(semver.rcompare) // sort in descending order
-		.filter(
-			// only include highest patch number per major.minor version & ensure each entry is unique
-			(value, index, self) =>
-				self.indexOf(
-					self.find((x) =>
-						semver.satisfies(x, `${value.major}.${value.minor}.x`)
-					)
-				) === index && self.indexOf(value) === index
-		);
+		.filter((dir) => semver.coerce(dir, { loose: true }))
+		.map((dir) => getSemanticVersion(dir))
+		.sort(semver.rcompare);
 }
 
 /**
  * Creates a string (of javascript) defining an array of all the versions to be included in the frontend select
- * @param semVers
+ * @param versions
+ * @param docRoot
+ * @param [stable='auto'] The version set in the options for the 'dev' alias.
+ * @param [dev='auto'] The version set in the options for the 'dev' alias.
  * @returns
  */
-export function makeJsKeys(semVers: SemVer[]): string {
-	let js = `
-"use strict"
-
-export const DOC_VERSIONS = [
-	'stable',
-`;
-	for (const version of semVers.map((v) => getMinorVersion(v.version))) {
-		js += `	'${version}',\n`;
+export function makeJsKeys(
+	versions: version[],
+	docRoot: string,
+	stable: 'auto' | version = 'auto',
+	dev: 'auto' | version = 'auto'
+): string {
+	const stableVer = getSymlinkVersion('stable', docRoot);
+	const devVer = getSymlinkVersion('dev', docRoot);
+	const alias = getVersionAlias(stableVer, stable, dev);
+	const keys = [
+		alias, // add initial key (stable or dev)
+		...versions // add the major.minor versions
+			.map((v) => getMinorVersion(v))
+			.filter((v, i, s) => s.indexOf(v) === i),
+	];
+	if (
+		alias !== 'dev' && // initial key is not dev
+		((dev !== 'auto' && devVer === getSemanticVersion(dev)) || // explicit dev version
+			semver.lt(stableVer, devVer, true)) // dev version newer than stable
+	) {
+		keys.push('dev');
 	}
-	js += `	'dev'
-];
-`;
-	return js;
+	// finally, create the js string
+	const lines = [
+		'"use strict"',
+		'export const DOC_VERSIONS = [',
+		...keys.map((v) => `	'${v}',`),
+		'];',
+	];
+	return lines.join('\n').concat('\n');
 }
 
 /**
- * Creates a symlink for the stable release
- * @param docRoot
- * @param semVers
- * @param pegVersion
- * @param name
- */
-export function makeStableLink(
-	docRoot: string,
-	semVers: SemVer[],
-	pegVersion: version,
-	name: semanticAlias = 'stable'
-): void {
-	pegVersion = getMinorVersion(pegVersion);
-
-	const version = semver.coerce(pegVersion, { loose: true });
-	const srcVer = semVers.find((v) =>
-		semver.satisfies(v, `${version.major}.${version.minor}.x`)
-	);
-
-	if (!srcVer) {
-		throw new Error(`Document directory does not exist: ${pegVersion}`);
-	}
-
-	const stableSource = path.join(docRoot, getSemanticVersion(srcVer.version));
-	const stableTarget = path.join(docRoot, name);
-	fs.existsSync(stableTarget) && fs.unlinkSync(stableTarget);
-	fs.ensureSymlinkSync(stableSource, stableTarget, 'junction');
-}
-
-/**
- * Creates a symlink for the dev release
+ * Creates a symlink for an alias
+ * @param alias
  * @param docRoot
  * @param pegVersion
- * @param name
  */
-export function makeDevLink(
+export function makeAliasLink(
+	alias: semanticAlias,
 	docRoot: string,
-	pegVersion: version,
-	name: semanticAlias = 'dev'
+	pegVersion: version
 ): void {
 	pegVersion = getSemanticVersion(pegVersion);
-	const devSource = path.join(docRoot, pegVersion);
+	const stableSource = path.join(docRoot, pegVersion);
 
-	if (!fs.existsSync(devSource))
+	if (!fs.existsSync(stableSource))
 		throw new Error(`Document directory does not exist: ${pegVersion}`);
-	const devTarget = path.join(docRoot, name);
-	fs.existsSync(devTarget) && fs.unlinkSync(devTarget);
-	fs.ensureSymlinkSync(devSource, devTarget, 'junction');
+	const stableTarget = path.join(docRoot, alias);
+	fs.existsSync(stableTarget) && fs.unlinkSync(stableTarget);
+	fs.ensureSymlinkSync(stableSource, stableTarget, 'junction');
 }
 
 /**
@@ -155,12 +136,40 @@ export function makeDevLink(
  * @param docRoot
  */
 export function makeMinorVersionLinks(
-	semVers: SemVer[],
-	docRoot: string
+	versions: version[],
+	docRoot: string,
+	stable: 'auto' | version = 'auto',
+	dev: 'auto' | version = 'auto'
 ): void {
-	for (const v of semVers) {
-		const target = path.join(docRoot, getMinorVersion(v.version));
-		const src = path.join(docRoot, getSemanticVersion(v.version));
+	for (const version of versions
+		// get highest patch per version
+		.map((version) => {
+			// prefer stable where available
+			const highestStablePatch = versions.find(
+				(v) =>
+					getVersionAlias(v, stable, dev) === 'stable' &&
+					semver.satisfies(
+						v,
+						`${semver.major(version)}.${semver.minor(version)}.x`,
+						{ includePrerelease: true }
+					)
+			);
+			// fallback to highest patch
+			return (
+				highestStablePatch ??
+				versions.find((v) =>
+					semver.satisfies(
+						v,
+						`${semver.major(version)}.${semver.minor(version)}.x`,
+						{ includePrerelease: true }
+					)
+				)
+			);
+		})
+		// filter to unique values
+		.filter((v, i, s) => s.indexOf(v) === i)) {
+		const target = path.join(docRoot, getMinorVersion(version));
+		const src = path.join(docRoot, version);
 		fs.existsSync(target) && fs.unlinkSync(target);
 		fs.ensureSymlinkSync(src, target, 'junction');
 	}
@@ -185,7 +194,7 @@ export function getVersionsOptions(app: Application): versionsOptions {
  * @param version
  * @returns the paths
  */
-export function getPaths(app, version?: version) {
+export function getPaths(app: Application, version?: version) {
 	const defaultRootPath = path.join(process.cwd(), 'docs');
 	const rootPath = app.options.getValue('out') || defaultRootPath;
 	return {
@@ -217,6 +226,94 @@ export function handleAssets(targetPath: string, srcDir: string = __dirname) {
 		sourceAsset,
 		path.join(targetPath, 'assets/versionsMenu.js')
 	);
+}
+
+/**
+ * Gets the {@link semanticAlias alias} of the given version, e.g. 'stable' or 'dev'.
+ * @remarks
+ * Versions {@link https://semver.org/#spec-item-4 lower than 1.0.0} or
+ * {@link https://semver.org/#spec-item-9 with a pre-release label} (e.g. 1.0.0-alpha.1)
+ * will be considered 'dev'. All other versions will be considered 'stable'.
+ * @param [version] Defaults to the version from `package.json`
+ * @param [stable='auto'] The version set in the typedoc options for the 'stable' alias.
+ * @param [dev='auto'] The version set in the options for the 'dev' alias.
+ * @returns The {@link semanticAlias alias} of the given version.
+ */
+export function getVersionAlias(
+	version?: string,
+	stable: 'auto' | version = 'auto',
+	dev: 'auto' | version = 'auto'
+): semanticAlias {
+	version = getSemanticVersion(version);
+	if (stable !== 'auto' && version === getSemanticVersion(stable))
+		// version is marked as stable by user
+		return 'stable';
+	else if (dev !== 'auto' && version === getSemanticVersion(dev))
+		// version is marked as dev by user
+		return 'dev';
+	// semver.satisfies() automatically filters out prerelease versions by default
+	else return semver.satisfies(version, '>=1.0.0', true) ? 'stable' : 'dev';
+}
+
+/**
+ * Automatically parses the version number for a given {@link semanticAlias alias} based on
+ * typedoc options.
+ * @param alias The alias to parse, e.g. 'stable' or 'dev'.
+ * @param version The version set in the typedoc options for the alias.
+ * @param docRoot The path to the docs root.
+ * @param [stable='auto'] The version set in the typedoc options for the 'stable' alias.
+ * @param [dev='auto'] The version set in the options for the 'dev' alias.
+ * @returns The automatically parsed version number which should be used for the given alias.
+ */
+export function getAliasVersion(
+	alias: semanticAlias,
+	version: 'auto' | version,
+	docRoot: string,
+	stable: 'auto' | version = 'auto',
+	dev: 'auto' | version = 'auto'
+): version {
+	if (version !== 'auto') {
+		return getSemanticVersion(version); // user has explicitly specified a version, use it
+	}
+
+	// no explicit version set for alias, check if package version is a match
+	const packageVersion = getSemanticVersion();
+	if (getVersionAlias(packageVersion, stable, dev) === alias) {
+		// package version matches the alias
+		return packageVersion;
+	}
+
+	// package version is not a match, check symlink for alias
+	const symlinkVersion = getSymlinkVersion(alias, docRoot);
+	if (
+		symlinkVersion &&
+		getVersionAlias(symlinkVersion, stable, dev) === alias &&
+		(alias === 'stable' || semver.lt(packageVersion, symlinkVersion))
+	) {
+		// version symlinked alias is pointing to is a match
+		return symlinkVersion;
+	}
+
+	// no matches found, fall back to the package version
+	return packageVersion;
+}
+
+/**
+ * Gets the {@link version} a given symlink is pointing to.
+ * @param symlink The symlink path, relative to {@link docRoot}.
+ * @param docRoot The path to the docs root.
+ * @returns The version number parsed from the given symlink.
+ */
+export function getSymlinkVersion(symlink: string, docRoot: string): version {
+	const symlinkPath = path.join(docRoot, symlink);
+	if (
+		fs.existsSync(symlinkPath) &&
+		fs.lstatSync(symlinkPath).isSymbolicLink()
+	) {
+		// retrieve the version the symlink is pointing to
+		const targetPath = fs.readlinkSync(symlinkPath);
+		return getSemanticVersion(path.basename(targetPath));
+	}
 }
 
 /**

--- a/src/index.ts
+++ b/src/index.ts
@@ -23,8 +23,8 @@ export function load(app: Application) {
 		name: 'versions',
 		type: ParameterType.Mixed,
 		defaultValue: {
-			stable: vUtils.getMinorVersion(),
-			dev: vUtils.getSemanticVersion(),
+			stable: 'auto',
+			dev: 'auto',
 			domLocation: 'false',
 		} as versionsOptions,
 	});
@@ -55,13 +55,32 @@ export function load(app: Application) {
 		vUtils.handleJeckyll(rootPath, targetPath);
 
 		const directories = vUtils.getPackageDirectories(rootPath);
-		const semVers = vUtils.getSemVers(directories);
+		const versions = vUtils.getVersions(directories);
+		const stable = vUtils.getAliasVersion(
+			'stable',
+			vOptions.stable,
+			rootPath,
+			vOptions.stable,
+			vOptions.dev
+		);
+		const dev = vUtils.getAliasVersion(
+			'dev',
+			vOptions.dev,
+			rootPath,
+			vOptions.stable,
+			vOptions.dev
+		);
 
-		vUtils.makeStableLink(rootPath, semVers, vOptions.stable);
-		vUtils.makeDevLink(rootPath, vOptions.dev);
-		vUtils.makeMinorVersionLinks(semVers, rootPath);
+		vUtils.makeAliasLink('stable', rootPath, stable);
+		vUtils.makeAliasLink('dev', rootPath, dev);
+		vUtils.makeMinorVersionLinks(versions, rootPath);
 
-		const jsVersionKeys = vUtils.makeJsKeys(semVers);
+		const jsVersionKeys = vUtils.makeJsKeys(
+			versions,
+			rootPath,
+			vOptions.stable,
+			vOptions.dev
+		);
 		fs.writeFileSync(path.join(rootPath, 'versions.js'), jsVersionKeys);
 
 		fs.writeFileSync(

--- a/src/types.ts
+++ b/src/types.ts
@@ -12,12 +12,12 @@ export interface versionsOptions {
 	 * The minor version that you would like to be marked as `stable`
 	 * Defaults to the latest patch version of the version being built
 	 */
-	stable?: version;
+	stable?: version | 'auto';
 	/**
 	 * The version that you would like to be marked as `dev`
 	 * Defaults to the latest patch version of the version being built
 	 */
-	dev?: version;
+	dev?: version | 'auto';
 	/**
 	 * A custom DOM location to render the HTML `select` dropdown corresponding to [typedoc render hooks](https://typedoc.org/api/interfaces/RendererHooks.html)
 	 * Default: Injects to left of header using vanilla js - not a typedoc render hook.

--- a/test/index.spec.ts
+++ b/test/index.spec.ts
@@ -66,10 +66,8 @@ describe('Unit testing for typedoc-plugin-versions', function () {
 			const directories = vUtils.getPackageDirectories(docsPath);
 			assert.deepEqual(
 				vUtils.getVersions(directories),
-				['0.10.1', '0.2.3', '0.1.1', '0.1.0', '0.0.0'].map((x) =>
-					vUtils.getSemanticVersion(x)
-				),
-				'did not return a correctly formatted SemVer[] array'
+				['v0.10.1', 'v0.2.3', 'v0.1.1', 'v0.1.0', 'v0.0.0'],
+				'did not return a correctly formatted version[] array'
 			);
 		});
 	});

--- a/test/index.spec.ts
+++ b/test/index.spec.ts
@@ -1,7 +1,6 @@
 import { assert } from 'chai';
 import path from 'path';
 import fs from 'fs-extra';
-import semver from 'semver';
 import * as vUtils from '../src/etc/utils';
 import { minorVerRegex, verRegex } from '../src/etc/utils';
 import {
@@ -33,19 +32,19 @@ describe('Unit testing for typedoc-plugin-versions', function () {
 				verRegex,
 				'did not provided a correctly formatted patch version'
 			);
+			assert.equal(vUtils.getSemanticVersion('0.0.0'), 'v0.0.0');
+			assert.equal(vUtils.getSemanticVersion('0.2.0'), 'v0.2.0');
+			assert.equal(vUtils.getSemanticVersion('1.2.0'), 'v1.2.0');
+			assert.equal(
+				vUtils.getSemanticVersion('1.2.0-alpha.1'),
+				'v1.2.0-alpha.1'
+			);
 		});
 		it('retrieves minor value from package.json', function () {
 			assert.match(
 				vUtils.getMinorVersion(),
 				minorVerRegex,
 				'did not return a correctly formatted minor version'
-			);
-		});
-		it('discards patch from semantic version string', function () {
-			assert.match(
-				vUtils.getSemanticVersion('v11.10.09-label'),
-				verRegex,
-				'did not strip the label from version string'
 			);
 		});
 	});
@@ -57,12 +56,12 @@ describe('Unit testing for typedoc-plugin-versions', function () {
 				'did not retrieve all semanticly named directories'
 			);
 		});
-		it('lists semantic versions correctly with highest patch', function () {
+		it('lists semantic versions correctly', function () {
 			const directories = vUtils.getPackageDirectories(docsPath);
 			assert.deepEqual(
-				vUtils.getSemVers(directories),
-				['0.10.1', '0.2.3', '0.1.1', '0.0.0'].map((x) =>
-					semver.parse(x, true)
+				vUtils.getVersions(directories),
+				['0.10.1', '0.2.3', '0.1.1', '0.1.0', '0.0.0'].map((x) =>
+					vUtils.getSemanticVersion(x)
 				),
 				'did not return a correctly formatted SemVer[] array'
 			);
@@ -71,52 +70,74 @@ describe('Unit testing for typedoc-plugin-versions', function () {
 	describe('creates browser assets', function () {
 		it('creates a valid js string from the sematic groups', function () {
 			const directories = vUtils.getPackageDirectories(docsPath);
-			const semVers = vUtils.getSemVers(directories);
+			const versions = vUtils.getVersions(directories);
 			assert.equal(
-				vUtils.makeJsKeys(semVers),
+				vUtils.makeJsKeys(versions, docsPath),
 				jsKeys,
 				'did not create a valid js string'
 			);
 		});
 	});
+	describe('infers stable and dev versions', function () {
+		it('correctly interprets versions as stable or dev', function () {
+			assert.equal(vUtils.getVersionAlias('v0.2.0'), 'dev');
+			assert.equal(vUtils.getVersionAlias('v0.2.0-alpha.1'), 'dev');
+			assert.equal(vUtils.getVersionAlias('v1.2.0-alpha.1'), 'dev');
+			assert.equal(vUtils.getVersionAlias('v1.2.0'), 'stable');
+		});
+		it('infers stable version automatically', function () {
+			assert.equal(
+				vUtils.getAliasVersion('stable', 'auto', docsPath),
+				vUtils.getSemanticVersion()
+			);
+			assert.equal(
+				vUtils.getAliasVersion('stable', 'v1.0.0', docsPath),
+				'v1.0.0'
+			);
+			assert.equal(
+				vUtils.getAliasVersion('stable', 'v1.0.0-alpha.1', docsPath),
+				'v1.0.0-alpha.1'
+			);
+		});
+		it('infers dev version automatically', function () {
+			assert.equal(
+				vUtils.getAliasVersion('dev', 'auto', docsPath),
+				vUtils.getSemanticVersion()
+			);
+			assert.equal(
+				vUtils.getAliasVersion('dev', 'v0.2.0', docsPath),
+				'v0.2.0'
+			);
+			assert.equal(
+				vUtils.getAliasVersion('dev', 'v0.2.0-alpha.1', docsPath),
+				'v0.2.0-alpha.1'
+			);
+		});
+	});
 	describe('creates symlinks', function () {
 		it('creates a stable version symlink', function () {
-			const directories = vUtils.getPackageDirectories(docsPath);
-			const semVers = vUtils.getSemVers(directories);
-			vUtils.makeStableLink(docsPath, semVers, 'v0.1');
+			vUtils.makeAliasLink('stable', docsPath, 'v0.1');
 			const link = path.join(docsPath, 'stable');
 			assert.isTrue(
 				fs.existsSync(link),
 				'did not create a stable symlink'
 			);
-			assert.isTrue(
-				/test[/|\\]stubs[/|\\]docs[/|\\]v0.1.[1$|1/$|1\\$]/.test(
-					fs.readlinkSync(link)
-				),
-				'did not link the stable symlink correctly'
-			);
 			assert.throws(() => {
-				vUtils.makeStableLink(docsPath, semVers, 'v0.11');
+				vUtils.makeAliasLink('stable', docsPath, 'v0.11');
 			}, 'Document directory does not exist: v0.11');
 		});
 		it('creates a dev version symlink', function () {
-			vUtils.makeDevLink(docsPath, 'v0.1.0');
+			vUtils.makeAliasLink('dev', docsPath, 'v0.1.0');
 			const link = path.join(docsPath, 'dev');
 			assert.isTrue(fs.existsSync(link), 'did not create a dev symlink');
-			assert.isTrue(
-				/test[/|\\]stubs[/|\\]docs[/|\\]v0.1.[0$|0/$|0\\$]/.test(
-					fs.readlinkSync(link)
-				),
-				'did not link the dev symlink correctly'
-			);
 			assert.throws(() => {
-				vUtils.makeDevLink(docsPath, 'v0.11.1');
+				vUtils.makeAliasLink('dev', docsPath, 'v0.11.1');
 			}, 'Document directory does not exist: v0.11.1');
 		});
 		it('creates all minor version links', function () {
 			const directories = vUtils.getPackageDirectories(docsPath);
-			const semVers = vUtils.getSemVers(directories);
-			vUtils.makeMinorVersionLinks(semVers, docsPath);
+			const versions = vUtils.getVersions(directories);
+			vUtils.makeMinorVersionLinks(versions, docsPath);
 			stubSemanticLinks.forEach((link) => {
 				const linkPath = path.join(docsPath, link);
 				assert.isTrue(

--- a/test/stubs/stubs.ts
+++ b/test/stubs/stubs.ts
@@ -12,15 +12,12 @@ export const stubRootPath =
 export const stubTargetPath = (version) =>
 	path.join(stubRootPath, getSemanticVersion(version));
 
-export const jsKeys = `
-"use strict"
-
+export const jsKeys = `"use strict"
 export const DOC_VERSIONS = [
-	'stable',
+	'dev',
 	'v0.10',
 	'v0.2',
 	'v0.1',
 	'v0.0',
-	'dev'
 ];
 `;

--- a/typedoc.json
+++ b/typedoc.json
@@ -8,8 +8,5 @@
 	"excludeExternals": true,
 	"logLevel": "Verbose",
 	"plugin": ["./dist"],
-	"includeVersion": true,
-	"versions": {
-		"stable": "0.1"
-	}
+	"includeVersion": true
 }


### PR DESCRIPTION
This is a mirror of https://github.com/citkane/typedoc-plugin-versions/pull/10, intended to make it easier to view the changes between https://github.com/citkane/typedoc-plugin-versions/pull/9 and https://github.com/citkane/typedoc-plugin-versions/pull/10.

@citkane